### PR TITLE
Update GreenPill.cs

### DIFF
--- a/Cards/GreenPill.cs
+++ b/Cards/GreenPill.cs
@@ -14,7 +14,7 @@ namespace BPP.Cards
         public override void SetupCard(CardInfo cardInfo, Gun gun, ApplyCardStats cardStats, CharacterStatModifiers statModifiers, Block block)
         {
             //Edits values on card itself, which are then applied to the player in `ApplyCardStats`
-            gun.damage *= 0.80f;
+            gun.damage = 0.80f;
             UnityEngine.Debug.Log($"[{BPP.ModInitials}][Card] {GetTitle()} has been setup.");
         }
         public override void OnAddCard(Player player, Gun gun, GunAmmo gunAmmo, CharacterData data, HealthHandler health, Gravity gravity, Block block, CharacterStatModifiers characterStats)


### PR DESCRIPTION
Need to set damage, not multiply it, `SetupCard` is run multiple times, resulting in drastically decreased damage.